### PR TITLE
refractor: Improve navigation logic and prevent duplicate routes

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/navigation/NavigationActions.kt
@@ -67,10 +67,15 @@ open class NavigationActions(
    */
   open fun navigateTo(screen: Screen) {
     // If the user is already on the destination, do nothing
-    if (currentRoute() == screen.route) {
-      return
+    if (currentRoute() != screen.route) {
+      navController.navigate(screen.route) {
+        if (screen.route == Screen.Main.route || screen.route == Screen.SignIn.route) {
+          popUpTo(navController.graph.startDestinationId) { inclusive = true }
+        }
+        restoreState = true
+        launchSingleTop = true
+      }
     }
-    navController.navigate(screen.route) { restoreState = true }
   }
 
   /** Navigate back to the previous screen in the back stack. */


### PR DESCRIPTION
This commit refractors the `navigateTo` function in `NavigationActions.kt` to provide a more robust navigation.

- Prevents navigating to the same screen multiple times by adding a check (`currentRoute() != screen.route`).
- Implements `popUpTo` logic for `Main` and `SignIn` screens to clear the back stack and prevent unexpected behavior when navigating to top-level destinations.
- Ensures `launchSingleTop` is true to avoid creating multiple instances of the same screen on top of the stack.

Closes #83