### PR TITLE
fix: make sample cards responsive on small screens

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -39,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -46,6 +48,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -85,6 +88,14 @@ object MainScreenTestTags {
 fun MainScreen(mainViewModel: MainViewModel = viewModel(), navigateToProfile: () -> Unit = {}) {
   val discoverSamples by mainViewModel.discoverSamples.collectAsState()
   val followedSamples by mainViewModel.followedSamples.collectAsState()
+
+  val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+  val horizontalPadding = 30.dp
+  val spacing = 25.dp
+  // Depends on the size of the screen
+  val maxColumns = if (screenWidth < 360.dp) 1 else 2
+  val cardWidth = (screenWidth - horizontalPadding * 2 - spacing) / 2
+
   Scaffold(
       topBar = {
         Column {
@@ -136,11 +147,27 @@ fun MainScreen(mainViewModel: MainViewModel = viewModel(), navigateToProfile: ()
                       .testTag(MainScreenTestTags.LAZY_COLUMN_SAMPLE_LIST)) {
                 // ----------------Discover Section-----------------
                 item { SectionHeader(title = "Discover") }
-                items(discoverSamples.chunked(2)) { samples -> SampleCardRow(samples) }
-
+                item {
+                  LazyRow(
+                      horizontalArrangement = Arrangement.spacedBy(spacing),
+                      modifier = Modifier.fillMaxWidth()) {
+                        // As this element is horizontally scrollable,we can let 2
+                        val columns = discoverSamples.chunked(2)
+                        items(columns) { samplesColumn ->
+                          Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+                            samplesColumn.forEach { samples ->
+                              SampleCard(samples, cardWidth = cardWidth)
+                            }
+                          }
+                        }
+                      }
+                }
                 // ----------------Followed Section-----------------
                 item { SectionHeader(title = "Followed") }
-                items(followedSamples.chunked(2)) { samples -> SampleCardRow(samples) }
+                // If the screen is too small, it will display 1 Card instead of 2
+                items(followedSamples.chunked(maxColumns)) { samples ->
+                  SampleCardRow(samples, cardWidth = cardWidth)
+                }
               }
         }
       }
@@ -173,21 +200,21 @@ fun SectionHeader(title: String) {
 
 // ----------------Sample Card in Row (2 per row)-----------------
 @Composable
-fun SampleCardRow(samples: List<Sample>) {
+fun SampleCardRow(samples: List<Sample>, cardWidth: Dp) {
   Row(
       modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-      horizontalArrangement = Arrangement.SpaceBetween) {
-        samples.forEach { sample -> SampleCard(sample) }
+      horizontalArrangement = Arrangement.spacedBy(25.dp)) {
+        samples.forEach { sample -> SampleCard(sample, cardWidth = cardWidth) }
       }
 }
 
 // ----------------Sample Card-----------------
 @Composable
-fun SampleCard(sample: Sample) {
+fun SampleCard(sample: Sample, cardWidth: Dp) {
   val mediaPlayer = LocalMediaPlayer.current
   Card(
       modifier =
-          Modifier.width(150.dp)
+          Modifier.width(cardWidth)
               .height(166.dp)
               .clickable(
                   onClick = { mediaPlayer.togglePlay(mediaPlayer.getUriFromSampleId(sample.id)) })
@@ -348,10 +375,3 @@ fun IconWithTextPainter(
     Text(text, color = NepTuneTheme.colors.background, fontSize = 10.sp)
   }
 }
-
-/*
-@Preview
-@Composable
-fun MainScreenPreview() {
-  MainScreen()
-}*/


### PR DESCRIPTION
# What Changes
This pull request makes sample cards on the main screen responsive.
## Key Implementations :
- **Discover section:** cards can be scrolled horizontally.  
- **Followed section:** layout adapts to screen width, showing 1 or 2 cards in a row. 
## Notes
Closes #118 
