### PR TITLE
feat: Lock screen orientation to portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,9 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/title_activity_main"
-            android:theme="@style/Theme.SampleApp">
+            android:theme="@style/Theme.SampleApp"
+            android:screenOrientation="portrait"
+            tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
This small PR locks the MainActivity to portrait orientation, preventing the app from rotating into landscape mode.

Why is this change necessary?
The app's current UI is designed only for a vertical layout. Forcing portrait mode ensures a consistent user experience and prevents potential UI issues (e.g., broken layouts, content being cut off) that occur when the device is rotated.

Closes #122 

(this description was made using AI)