### PR TITLE
ci: add GitHub Actions workflow to build Android APK

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,32 @@
+name: Build Android APK
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: Upload Release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: NeptuneApp-Release-APK
+          path: app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
# What Changes
This pull request adds a GitHub Actions workflow to automatically build the Android release APK whenever code is pushed to the `main` branch (or triggered manually).
## Key Implementations :
- Builds the release APK whenever code is pushed to `main`.
## Notes
Closes #160 
