### PR TITLE
fix: revert JaCoCo version to 0.8.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       # This step generates the coverage report which will be uploaded to sonar
       - name: Generate Coverage Report
         run: |
-          ./gradlew clean jacocoTestReport --no-daemon --refresh-dependencies
+          ./gradlew jacocoTestReport
 
       # Upload the various reports to sonar
       - name: Upload report to SonarCloud

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,20 +10,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization") version "1.9.22"
 }
 
-jacoco {
-    toolVersion = "0.8.13"
-}
-
-configurations.all {
-    resolutionStrategy {
-        force(
-            "org.jacoco:org.jacoco.agent:0.8.13",
-            "org.jacoco:org.jacoco.build:0.8.13",
-            "org.ow2.asm:asm:9.8"
-        )
-    }
-}
-
 android {
     namespace = "com.neptune.neptune"
     compileSdk = 34
@@ -63,7 +49,7 @@ android {
     }
 
     testCoverage {
-        jacocoVersion = "0.8.13"
+        jacocoVersion = "0.8.11"
     }
 
     buildFeatures {


### PR DESCRIPTION
# What Changes
Reverted JaCoCo back to 0.8.11 has it was apparently not 0.8.8.
## Notes
There is many problems / mysteries around JaCoCo.
My mistake was that I accidentaly put a clean keyword in the ci for coverage report, but even though I changed it the version of JaCoCo causing all the errors messages don't seems to be bind to the version in the build.gradle.