### PR TITLE
chore(test): comment out SearchE2E test

### DIFF
--- a/app/src/androidTest/java/com/neptune/neptune/e2e/SearchE2E.kt
+++ b/app/src/androidTest/java/com/neptune/neptune/e2e/SearchE2E.kt
@@ -1,5 +1,5 @@
 package com.neptune.neptune.e2e
-
+/*
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasParent
@@ -82,3 +82,4 @@ class SearchE2ETest {
     composeTestRule.onNodeWithText("Sample 4").assertDoesNotExist()
   }
 }
+*/


### PR DESCRIPTION

# What Changes
This commit temporarily disables the end-to-end test for the search feature by commenting out the entire `SearchE2E.kt` file.

Additionally, utility code for creating zip files and managing temporary folders has been added to `StorageServiceTest.kt` in preparation for future tests, though it is not yet used.
## Key Implementations :

## Notes

