### PR TITLE
fix(firebase-functions): correct linting errors and add region attribute

### DIFF
--- a/functions/src/generateSamplePreview.ts
+++ b/functions/src/generateSamplePreview.ts
@@ -21,7 +21,7 @@ if (typeof ffmpegStatic === "string") {
 
 
 export const generateSamplePreview = onObjectFinalized(
-  {timeoutSeconds: 540, memory: "1GiB"},
+  {timeoutSeconds: 540, memory: "1GiB", region: "us-east1"},
   async (event) => {
     const objectPath = event.data?.name ?? "";
     const match = objectPath.match(/^samples\/([^/]+)\.zip$/);
@@ -79,16 +79,13 @@ export const generateSamplePreview = onObjectFinalized(
         {storagePreviewSamplePath: previewPath},
         {merge: true}
       );
-
       logger.info("Preview generated", {sampleId, previewPath});
-
     } catch (error) {
       logger.error("Failed to generate preview", {sampleId, error});
       throw error;
     } finally {
       await rm(tmpRoot, {recursive: true, force: true});
     }
-
   }
 
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -24,4 +24,4 @@ import {setGlobalOptions} from "firebase-functions";
 // this will be the maximum concurrent request count.
 setGlobalOptions({maxInstances: 10});
 
-export { generateSamplePreview } from "./generateSamplePreview";
+export {generateSamplePreview} from "./generateSamplePreview";


### PR DESCRIPTION
# What Changes

This pull request consists in correcting linting errors in firebase functions `index.ts` and `generateSamplePreview.ts`, and adding a region attribute `us-east1` to `generateSamplePreview.onObjectFinalized` in order to be able to deploy firebase functions.

## Key Implementations :

- I removed blank lines, so that block is not padded by blank lines (as linter was suggesting)
- I removed leading and trailing spaces in `index.ts` (after `{` and before `}`, as linter was suggesting)
- I added a region attribute `us-east1`, because our Firebase Storage bucket is physically located in us-east1, and a Cloud Function that listens to that bucket must be in the same region (by default, it was in us-central1)

## Notes
Closes #224 
