### PR TITLE
fix: remove the avatar's blinking in main screen

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -63,7 +62,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
@@ -78,8 +76,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -180,18 +176,6 @@ fun MainScreen(
   // Depends on the size of the screen
   val maxColumns = if (screenWidth < 360.dp) 1 else 2
   val cardWidth = (screenWidth - horizontalPadding * 2 - spacing) / 2
-
-  val lifecycleOwner = LocalLifecycleOwner.current
-  // This effect was created using AI assistance
-  DisposableEffect(lifecycleOwner) {
-    val observer = LifecycleEventObserver { _, event ->
-      if (event == Lifecycle.Event.ON_RESUME) {
-        mainViewModel.onResume()
-      }
-    }
-    lifecycleOwner.lifecycle.addObserver(observer)
-    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-  }
 
   fun onCommentClicked(sample: Sample) {
     mainViewModel.observeCommentsForSample(sample.id)

--- a/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
@@ -85,7 +85,7 @@ class MainViewModel(
       loadSamplesFromFirebase()
     }
     auth.addAuthStateListener(authListener)
-    forceRefreshAndLoadAvatar()
+    loadAvatar()
   }
 
   private fun loadSamplesFromFirebase() {
@@ -102,16 +102,12 @@ class MainViewModel(
     }
   }
 
-  fun onResume() {
-    forceRefreshAndLoadAvatar()
-  }
-
   override fun onCleared() {
     super.onCleared()
     auth.removeAuthStateListener(authListener)
   }
 
-  private fun forceRefreshAndLoadAvatar() {
+  private fun loadAvatar() {
     viewModelScope.launch {
       val storagePath = avatarStoragePath
       val fileName = avatarFileName


### PR DESCRIPTION
# What Changes
This pull request refactors the avatar loading logic by removing the `onResume` lifecycle dependency.
## Key Implementations :
- Renamed `forceRefreshAndLoadAvatar()` to `loadAvatar()` in `MainViewModel` for clarity.
- Removed the `onResume()` method from `MainViewModel`.
- Deleted the `DisposableEffect` in `MainScreen.kt` that was responsible for calling `mainViewModel.onResume()` on every `ON_RESUME` lifecycle event.
## Notes
Closes #225
