### PR TITLE
fix: set default theme to dark mode

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/settings/SettingsViewModel.kt
@@ -24,7 +24,7 @@ class SettingsViewModel(private val themeDataStore: ThemeDataStore) : ViewModel(
       themeDataStore.theme.stateIn(
           scope = viewModelScope,
           started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
-          initialValue = ThemeSetting.SYSTEM)
+          initialValue = ThemeSetting.DARK)
 
   fun updateTheme(newTheme: ThemeSetting) {
     viewModelScope.launch { themeDataStore.setTheme(newTheme) }


### PR DESCRIPTION
# What Changes
This commit changes the initial value for the theme setting to dark mode.

## Key Implementations :
- the initial value change in the `SettingsViewModel` from `ThemeSetting.SYSTEM` to `ThemeSetting.DARK`.
## Notes
Closes #267 
