### PR TITLE
refactor: standardize top bar padding

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/profile/ProfileScreen.kt
@@ -72,7 +72,6 @@ private val SectionVerticalSpacing = 40.dp
 private val LargeSectionSpacing = 100.dp
 private val BottomButtonBottomPadding = 24.dp
 private val ButtonIconSpacing = 8.dp
-private val TopBarHorizontalPadding = 8.dp
 private val TagsSpacing = 8.dp
 private val StatBlockLabelSpacing = 8.dp
 
@@ -245,7 +244,7 @@ private fun ProfileViewContent(
       topBar = {
         Column {
           Row(
-              modifier = Modifier.fillMaxWidth().padding(horizontal = TopBarHorizontalPadding),
+              modifier = Modifier.fillMaxWidth(),
               horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically) {
                 // Go Back Button

--- a/app/src/main/java/com/neptune/neptune/ui/settings/SettingsAccountScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/settings/SettingsAccountScreen.kt
@@ -41,16 +41,14 @@ fun SettingsAccountScreen(
   Scaffold(
       topBar = {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp, horizontal = 12.dp),
             verticalAlignment = Alignment.CenterVertically) {
-              IconButton(
-                  onClick = goBack,
-                  modifier = Modifier.padding(vertical = 30.dp, horizontal = 17.dp)) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowBackIosNew,
-                        contentDescription = "Go Back",
-                        tint = NepTuneTheme.colors.onBackground)
-                  }
+              IconButton(onClick = goBack) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBackIosNew,
+                    contentDescription = "Go Back",
+                    tint = NepTuneTheme.colors.onBackground)
+              }
             }
       },
       containerColor = NepTuneTheme.colors.background) { innerPadding ->

--- a/app/src/main/java/com/neptune/neptune/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/settings/SettingsScreen.kt
@@ -49,7 +49,7 @@ fun SettingsScreen(
 ) {
   Scaffold(
       topBar = {
-        Column {
+        Column(modifier = Modifier.padding(vertical = 8.dp)) {
           CenterAlignedTopAppBar(
               title = {
                 Text(
@@ -65,14 +65,12 @@ fun SettingsScreen(
                     textAlign = TextAlign.Center)
               },
               navigationIcon = {
-                IconButton(
-                    onClick = goBack,
-                    modifier = Modifier.padding(vertical = 30.dp, horizontal = 17.dp)) {
-                      Icon(
-                          imageVector = Icons.Default.ArrowBackIosNew,
-                          contentDescription = "Go Back",
-                          tint = NepTuneTheme.colors.onBackground)
-                    }
+                IconButton(onClick = goBack, modifier = Modifier.padding(horizontal = 12.dp)) {
+                  Icon(
+                      imageVector = Icons.Default.ArrowBackIosNew,
+                      contentDescription = "Go Back",
+                      tint = NepTuneTheme.colors.onBackground)
+                }
               },
               colors =
                   TopAppBarDefaults.centerAlignedTopAppBarColors(

--- a/app/src/main/java/com/neptune/neptune/ui/settings/SettingsThemeScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/settings/SettingsThemeScreen.kt
@@ -52,17 +52,15 @@ fun SettingsThemeScreen(
       topBar = {
         Column {
           Row(
-              modifier = Modifier.fillMaxWidth(),
+              modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp, horizontal = 16.dp),
               horizontalArrangement = Arrangement.Start,
               verticalAlignment = Alignment.CenterVertically) {
-                IconButton(
-                    onClick = goBack,
-                    modifier = Modifier.padding(vertical = 30.dp, horizontal = 17.dp)) {
-                      Icon(
-                          imageVector = Icons.Default.ArrowBackIosNew,
-                          contentDescription = "Go Back",
-                          tint = NepTuneTheme.colors.onBackground)
-                    }
+                IconButton(onClick = goBack) {
+                  Icon(
+                      imageVector = Icons.Default.ArrowBackIosNew,
+                      contentDescription = "Go Back",
+                      tint = NepTuneTheme.colors.onBackground)
+                }
               }
         }
       },


### PR DESCRIPTION
# What Changes

This pull request refactors the padding and layout of the top bars across multiple screens to ensure a consistent look and feel.

## Key Implementations :
- Removed an unused padding variable in `ProfileScreen.kt`.
- Adjusted padding on the top bar `Row` and back button `IconButton` in `SettingsAccountScreen.kt`, `SettingsThemeScreen.kt`, and `SettingsScreen.kt` for better alignment and spacing.
## Notes
Closes #269
