### PR TITLE
fix: change parameters order of comment creation

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
@@ -343,7 +343,7 @@ open class MainViewModel(
       val authorId = profile?.uid ?: auth?.currentUser?.uid ?: "unknown"
       val authorName = profile?.username ?: defaultName
       val authorProfilePicUrl = userAvatar.value ?: ""
-      sampleRepo.addComment(sampleId, authorId, authorName, authorProfilePicUrl, text.trim())
+      sampleRepo.addComment(sampleId, authorId, authorName, text.trim(), authorProfilePicUrl)
     }
   }
 


### PR DESCRIPTION
This pull request makes a small change to the parameter order when calling the `addComment` method in `MainViewModel`. The `authorProfilePicUrl` argument is now passed after `text.trim()` instead of before it, likely to match the updated method signature.

- Changed the order of parameters in the `addComment` call within `MainViewModel` to pass `authorProfilePicUrl` after `text.trim()`.

Closes #348 