### PR TITLE
fix: false positive no connection

### DIFF
--- a/app/src/test/java/com/neptune/neptune/ui/projectList/ProjectListViewModelTest.kt
+++ b/app/src/test/java/com/neptune/neptune/ui/projectList/ProjectListViewModelTest.kt
@@ -1,8 +1,11 @@
 package com.neptune.neptune.ui.projectList
 
+import android.content.Context
+import android.net.ConnectivityManager
 import android.net.Uri
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
+import com.neptune.neptune.NepTuneApplication
 import com.neptune.neptune.data.storage.StorageService
 import com.neptune.neptune.domain.model.MediaItem
 import com.neptune.neptune.domain.port.MediaRepository
@@ -54,9 +57,16 @@ class ProjectListViewModelTest {
   fun setUp() {
     Dispatchers.setMain(testDispatcher)
 
+    val mockContext = mockk<Context>(relaxed = true)
+    val mockConnectivityManager = mockk<ConnectivityManager>(relaxed = true)
+
     // Mock generic android dependencies that might be touched
     mockkStatic(Uri::class)
     every { Uri.fromFile(any()) } returns mockk()
+
+    every { mockContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns
+        mockConnectivityManager
+    NepTuneApplication.appContext = mockContext
 
     // Default: User logged in, Network Online
     every { auth.currentUser } returns firebaseUser


### PR DESCRIPTION



# What Changes
This pull request refactors how network connectivity is observed in `BaseSampleFeedViewModel`, `PostViewModel`, and `ProjectListViewModel`. The previous implementation, which used a private `MutableStateFlow` updated by collecting from `NetworkConnectivityObserver`, has been replaced with a more concise and robust approach using the `stateIn` operator.
## Key Implementations :

- Replaced `MutableStateFlow` and manual collection of `isOnline` with a `StateFlow` created directly from the `NetworkConnectivityObserver().isOnline` flow using `stateIn`.
- Configured `stateIn` with `SharingStarted.WhileSubscribed(5000L)` to efficiently share the connectivity state among subscribers and keep it active for 5 seconds after the last subscriber is gone.
- Removed now-redundant `init` blocks and `collectLatest` logic for network status updates in the affected ViewModels.
- Updated `ProjectListViewModel` to no longer trigger a project refresh directly on connectivity change, simplifying the logic.
- Adjusted `ProjectListViewModelTest` to mock the application context required by `NetworkConnectivityObserver`.
## Notes
Closes #367
The commit message and this PR description were made using AI assistance.