### PR TITLE
fix: filter samples in Discover and Followed feeds

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/feed/FeedScreen.kt
@@ -187,11 +187,12 @@ private fun FeedContent(
       label = "ListTransition",
       animationSpec = tween(durationMillis = effectDuration),
       modifier = modifier.background(NepTuneTheme.colors.background)) { type ->
-        val (currentSamples, currentState) =
+        val (rawSamples, currentState) =
             when (type) {
               FeedType.DISCOVER -> discoverSamples to discoverListState
               FeedType.FOLLOWED -> followedSamples to followedListState
             }
+        val currentSamples = rawSamples.filter { it.storagePreviewSamplePath.isNotBlank() }
         LazyColumn(
             state = currentState,
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
@@ -136,7 +136,10 @@ open class MainViewModel(
           _recommendedSamples.value = emptyList()
           return@launch
         }
-        val candidates = allSamplesCache
+        val candidates =
+            allSamplesCache.filter { sample ->
+              sample.ownerId !in latestFollowing && sample.ownerId != auth.currentUser?.uid
+            }
         if (candidates.isEmpty()) {
           Log.d("RecoDebug", "No candidates (cache empty) – skipping ranking")
           _recommendedSamples.value = emptyList()


### PR DESCRIPTION
# What Changes
This pull request introduces filtering logic to refine the samples displayed in the "Discover" and "Followed" feeds, ensuring a more relevant user experience.
## Key Implementations :

- **`MainViewModel.kt`**: The "Discover" feed recommendations are now filtered to exclude samples created by the current user or by users they already follow.
- **`FeedScreen.kt`**: Both feeds now filter out samples that do not have a valid `storagePreviewSamplePath`, preventing the display of items without a playable preview.
## Notes
Closes #369
The commit message and this PR description were made using AI assistance.