### PR TITLE
fix: support processed audio as fallback when preview is missing

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/feed/BaseSampleFeedViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/feed/BaseSampleFeedViewModel.kt
@@ -133,9 +133,10 @@ abstract class BaseSampleFeedViewModel(
 
   /** Function to trigger loading */
   override fun loadSampleResources(sample: Sample) {
+    val effectivePath =
+        sample.storagePreviewSamplePath.ifBlank { sample.storageProcessedSamplePath }
     val currentResources = _sampleResources.value[sample.id]
-    if (currentResources != null &&
-        currentResources.loadedSamplePath == sample.storagePreviewSamplePath) {
+    if (currentResources != null && currentResources.loadedSamplePath == effectivePath) {
       return
     }
 
@@ -153,8 +154,7 @@ abstract class BaseSampleFeedViewModel(
         val coverUrl =
             if (sample.storageImagePath.isNotBlank()) getSampleCoverUrl(sample.storageImagePath)
             else null
-        val audioUrl =
-            if (sample.storagePreviewSamplePath.isNotBlank()) getSampleAudioUrl(sample) else null
+        val audioUrl = if (effectivePath.isNotBlank()) getSampleAudioUrl(sample) else null
         val waveform = getSampleWaveform(sample)
 
         _sampleResources.update { current ->
@@ -167,7 +167,7 @@ abstract class BaseSampleFeedViewModel(
                       audioUrl = audioUrl,
                       waveform = waveform,
                       isLoading = false,
-                      loadedSamplePath = sample.storagePreviewSamplePath))
+                      loadedSamplePath = effectivePath))
         }
       } catch (e: Exception) {
         Log.e("BaseSampleFeedViewModel", "Error loading sample resources: ${e.message}")
@@ -214,7 +214,7 @@ abstract class BaseSampleFeedViewModel(
   }
 
   private suspend fun getSampleAudioUrl(sample: Sample): String? {
-    val storagePath = sample.storagePreviewSamplePath
+    val storagePath = sample.storagePreviewSamplePath.ifBlank { sample.storageProcessedSamplePath }
     if (storagePath.isBlank()) return null
     if (audioUrlCache.containsKey(storagePath)) return audioUrlCache[storagePath]
 

--- a/app/src/main/java/com/neptune/neptune/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/feed/FeedScreen.kt
@@ -192,7 +192,10 @@ private fun FeedContent(
               FeedType.DISCOVER -> discoverSamples to discoverListState
               FeedType.FOLLOWED -> followedSamples to followedListState
             }
-        val currentSamples = rawSamples.filter { it.storagePreviewSamplePath.isNotBlank() }
+        val currentSamples =
+            rawSamples.filter {
+              it.storageProcessedSamplePath.isNotBlank() || it.storagePreviewSamplePath.isNotBlank()
+            }
         LazyColumn(
             state = currentState,
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/neptune/neptune/ui/feed/SampleFeedItems.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/feed/SampleFeedItems.kt
@@ -36,7 +36,7 @@ fun LazyListScope.sampleFeedItems(
     iconSize: Dp = 20.dp,
 ) {
   items(samples) { sample ->
-    LaunchedEffect(sample.id, sample.storagePreviewSamplePath) {
+    LaunchedEffect(sample.id, sample.storagePreviewSamplePath, sample.storageProcessedSamplePath) {
       controller.loadSampleResources(sample)
     }
     val resources = sampleResources[sample.id] ?: SampleResourceState()

--- a/app/src/main/java/com/neptune/neptune/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainScreen.kt
@@ -411,7 +411,10 @@ private fun SampleSectionLazyRow(
       horizontalArrangement = Arrangement.spacedBy(spacing),
       contentPadding = PaddingValues(horizontal = horizontalPadding),
       modifier = Modifier.fillMaxWidth()) {
-        val validSamples = samples.filter { it.storagePreviewSamplePath.isNotBlank() }
+        val validSamples =
+            samples.filter {
+              it.storageProcessedSamplePath.isNotBlank() || it.storagePreviewSamplePath.isNotBlank()
+            }
         val columns = validSamples.chunked(rowsPerColumn)
 
         items(columns) { samplesColumn ->

--- a/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
@@ -185,10 +185,17 @@ open class MainViewModel(
               val existingIds = allSamplesCache.map { it.id }.toSet()
               allSamplesCache = visibleSamples
 
-              val readySamples = visibleSamples.filter { it.storagePreviewSamplePath.isNotBlank() }
+              val readySamples =
+                  visibleSamples.filter {
+                    it.storageProcessedSamplePath.isNotBlank() ||
+                        it.storagePreviewSamplePath.isNotBlank()
+                  }
               updateLists(readySamples)
 
-              val pendingSamples = visibleSamples.filter { it.storagePreviewSamplePath.isBlank() }
+              val pendingSamples =
+                  visibleSamples.filter {
+                    it.storageProcessedSamplePath.isBlank() && it.storagePreviewSamplePath.isBlank()
+                  }
               pendingSamples.forEach { pendingSample -> watchPendingSample(pendingSample.id) }
 
               val newSamples = visibleSamples.filter { it.id !in existingIds }
@@ -215,7 +222,9 @@ open class MainViewModel(
         sampleRepo
             .observeSample(sampleId)
             .first { updatedSample ->
-              updatedSample != null && updatedSample.storagePreviewSamplePath.isNotBlank()
+              updatedSample != null &&
+                  (updatedSample.storageProcessedSamplePath.isNotBlank() ||
+                      updatedSample.storagePreviewSamplePath.isNotBlank())
             }
             ?.let { finishedSample ->
               allSamplesCache =
@@ -261,7 +270,10 @@ open class MainViewModel(
     if (currentUser == null) {
       _userAvatar.value = null
       latestFollowing = emptyList()
-      updateLists(allSamplesCache.filter { it.storagePreviewSamplePath.isNotBlank() })
+      updateLists(
+          allSamplesCache.filter {
+            it.storageProcessedSamplePath.isNotBlank() || it.storagePreviewSamplePath.isNotBlank()
+          })
       return
     }
     viewModelScope.launch {

--- a/app/src/main/java/com/neptune/neptune/ui/profile/ProfileSamplesViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/profile/ProfileSamplesViewModel.kt
@@ -86,7 +86,9 @@ class ProfileSamplesViewModel(
       this@ProfileSamplesViewModel.sampleRepo.observeSamples().collectLatest { samples ->
         val filtered =
             samples.filter { sample ->
-              sample.ownerId == ownerId && sample.storagePreviewSamplePath.isNotBlank()
+              sample.ownerId == ownerId &&
+                  (sample.storageProcessedSamplePath.isNotBlank() ||
+                      sample.storagePreviewSamplePath.isNotBlank())
             }
         _samples.value = filtered
         refreshLikeStates(filtered, _likedSamples)

--- a/app/src/main/java/com/neptune/neptune/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/search/SearchViewModel.kt
@@ -286,7 +286,11 @@ open class SearchViewModel(
               samples.filter { sample ->
                 sample.isPublic || sample.ownerId == currentUserId || (sample.ownerId in following)
               }
-          val readySamples = visibleSamples.filter { it.storagePreviewSamplePath.isNotBlank() }
+          val readySamples =
+              visibleSamples.filter {
+                it.storageProcessedSamplePath.isNotBlank() ||
+                    it.storagePreviewSamplePath.isNotBlank()
+              }
           allSamples.value = readySamples
           readySamples.forEach { loadSampleResources(it) }
           applyFilter(query)


### PR DESCRIPTION
# What Changes
This pull request updates the audio loading logic to handle the new `storageProcessedSamplePath` while maintaining backward compatibility. The system continues to prioritize the legacy `storagePreviewSamplePath`, but now falls back to the processed version if the preview is unavailable.
## Key Implementations :
- Updated filtering logic in `MainViewModel`, `SearchViewModel`, `FeedScreen`, `MainScreen`, and `ProfileSamplesViewModel` to consider a sample "ready" if either `storageProcessedSamplePath` or `storagePreviewSamplePath` is present.
- In `BaseSampleFeedViewModel`, `loadSampleResources` now checks for the preview path first, and uses `storageProcessedSamplePath` only if the preview is blank.
- The `LaunchedEffect` in `SampleFeedItems` now observes changes in `storageProcessedSamplePath` to update the UI correctly when the file becomes available.
## Notes
Closes #375
The commit messages and this PR description were made using AI assistance.
