### PR TITLE
refactor: remove verbose logging

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -3,9 +3,6 @@
 #include <android/log.h>
 #include "soundtouch/SoundTouch.h"
 
-#define LOG_TAG "NativeSoundTouch"
-#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
-
 using namespace soundtouch;
 
 

--- a/app/src/main/java/com/neptune/neptune/domain/usecase/ImportMediaUsecase.kt
+++ b/app/src/main/java/com/neptune/neptune/domain/usecase/ImportMediaUsecase.kt
@@ -1,6 +1,5 @@
 package com.neptune.neptune.domain.usecase
 
-import android.util.Log
 import com.neptune.neptune.NepTuneApplication.Companion.appContext
 import com.neptune.neptune.data.NeptunePackager
 import com.neptune.neptune.domain.model.MediaItem
@@ -52,13 +51,11 @@ open class ImportMediaUseCase(
         } catch (e: Exception) {
           // Ensure we attempt to delete the temporary local file on IO dispatcher
           val isLocalAudioDeleted = localAudio.delete()
-          Log.d("ImportMediaUseCase", "finalizeImport: $isLocalAudioDeleted")
           throw e
         }
 
     // Best-effort delete of the original file on IO dispatcher
     val isLocalAudioDeleted = localAudio.delete()
-    Log.d("ImportMediaUseCase", "finalizeImport: $isLocalAudioDeleted")
 
     val item =
         MediaItem(id = UUID.randomUUID().toString(), projectUri = projectZip.toURI().toString())

--- a/app/src/main/java/com/neptune/neptune/model/project/ProjectItemsRepositoryLocal.kt
+++ b/app/src/main/java/com/neptune/neptune/model/project/ProjectItemsRepositoryLocal.kt
@@ -18,7 +18,6 @@ class ProjectItemsRepositoryLocal(context: Context) : ProjectItemsRepository {
   private val projectsFile = File(context.filesDir, "projects.json")
   private val gson = Gson()
   private val mutex = Mutex()
-  private val appContext = context.applicationContext
 
   init {
     if (!projectsFile.exists()) {
@@ -87,23 +86,19 @@ class ProjectItemsRepositoryLocal(context: Context) : ProjectItemsRepository {
                 removed.audioPreviewLocalPath,
                 removed.imagePreviewLocalPath)
 
-        Log.d("ProjectItemsRepositoryLocal", "Deleting files: $pathsToDelete")
         pathsToDelete.forEach { path ->
           try {
             val file = File(path.removePrefix("file:"))
             if (file.exists()) {
-              Log.d("ProjectItemsRepositoryLocal", "Deleting file: $file")
               val deleted = file.delete()
-              if (deleted) {
-                Log.d("ProjectItemsRepositoryLocal", "Deleted file: $path")
-              } else {
-                Log.d("ProjectItemsRepositoryLocal", "Failed to delete file: $path")
+              if (!deleted) {
+                Log.e("ProjectItemsRepositoryLocal", "Failed to delete file: $path")
               }
             } else {
-              Log.d("ProjectItemsRepositoryLocal", "Failed to delete file: $path, does not exist")
+              Log.e("ProjectItemsRepositoryLocal", "Failed to delete file: $path, does not exist")
             }
           } catch (_: Exception) {
-            Log.d("ProjectItemsRepositoryLocal", "Failed to delete file: $path")
+            Log.e("ProjectItemsRepositoryLocal", "Failed to delete file: $path")
           }
         }
       }

--- a/app/src/main/java/com/neptune/neptune/model/project/TotalProjectItemsRepositoryCompose.kt
+++ b/app/src/main/java/com/neptune/neptune/model/project/TotalProjectItemsRepositoryCompose.kt
@@ -43,8 +43,6 @@ open class TotalProjectItemsRepositoryCompose(
           }
         }
 
-    Log.d("TotalRepo", "Merged Projects: $mergedProjects")
-
     // Return defensive copies of the items and the list itself so callers get new instances
     return mergedProjects.map { it.copy() }.toList()
   }

--- a/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/main/MainViewModel.kt
@@ -141,12 +141,10 @@ open class MainViewModel(
   fun loadRecommendations(limit: Int = 50) {
     viewModelScope.launch {
       try {
-        Log.d("RecoDebug", "loadRecommendations() START, cacheSize=${allSamplesCache.size}")
         if (auth?.currentUser == null) return@launch
         val recoUser = profileRepo.getCurrentRecoUserProfile()
         if (recoUser == null) {
           // Fallback when no user or profile: just show latest samples
-          Log.d("RecoDebug", "No recoUser profile (null) – skipping recommendations")
 
           _recommendedSamples.value = emptyList()
           return@launch
@@ -156,7 +154,6 @@ open class MainViewModel(
               sample.ownerId !in latestFollowing && sample.ownerId != auth.currentUser?.uid
             }
         if (candidates.isEmpty()) {
-          Log.d("RecoDebug", "No candidates (cache empty) – skipping ranking")
           _recommendedSamples.value = emptyList()
           return@launch
         }
@@ -165,9 +162,6 @@ open class MainViewModel(
                 user = recoUser, candidates = candidates, limit = limit)
         ranked.forEachIndexed { index, sample ->
           val score = RecommendationEngine.scoreSample(sample, recoUser, System.currentTimeMillis())
-          Log.d(
-              "RecoDebug",
-              "#$index  id=${sample.id}  name=${sample.name}  score=${"%.4f".format(score)}")
         }
         _recommendedSamples.value = ranked
       } catch (e: Exception) {

--- a/app/src/main/java/com/neptune/neptune/ui/sampler/SamplerViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/sampler/SamplerViewModel.kt
@@ -622,7 +622,6 @@ open class SamplerViewModel(
             }
 
         val sampleDuration = extractDurationFromUri(audioUri)
-        Log.d("SamplerViewModel", "URI audio loaded: $audioUri")
 
         val paramMap = projectData.parameters.associate { it.type to it.value }
 


### PR DESCRIPTION
# What Changes
This pull request removes various `Log.d` statements across the application to clean up the log output.
## Key Implementations :
- **`ImportMediaUsecase.kt`**: Removed logs for temporary file deletion status.
- **`MainViewModel.kt`**: Removed extensive debug logs from the recommendation loading logic.
- **`TotalProjectItemsRepositoryCompose.kt`**: Removed logging of merged project lists.
- **`SamplerViewModel.kt`**: Removed logging of the loaded audio URI.
- **`ProjectItemsRepositoryLocal.kt`**: Replaced detailed file deletion logs (`Log.d`) with error logs (`Log.e`) for failed deletions to focus on actual issues.
- **`native-lib.cpp`**: Removed the `LOGD` macro and its associated tag, which were used for logging in the native SoundTouch wrapper.
## Notes
Closes #393
The commit messages and this PR description were made using AI assistance.
