### PR TITLE
fix: calculate and constrain octave in `SamplerViewModel`

### DIFF
--- a/app/src/main/java/com/neptune/neptune/ui/sampler/SamplerViewModel.kt
+++ b/app/src/main/java/com/neptune/neptune/ui/sampler/SamplerViewModel.kt
@@ -751,7 +751,10 @@ open class SamplerViewModel(
             }
 
             val loadedPitchNote = NOTE_ORDER[pitchValue.roundToInt() % NOTE_ORDER.size]
-            val loadedPitchOctave = 4
+            // pitchValue stores NOTE_INDEX + (octave * NOTE_ORDER.size)
+            // Reconstruct note index and octave from the stored semitone-like value.
+            val pitchInt = pitchValue.roundToInt()
+            val loadedPitchOctave = (pitchInt / NOTE_ORDER.size).coerceIn(minOctave, maxOctave)
 
             current.copy(
                 attack = paramMap["attack"]?.coerceIn(0f, ADSR_MAX_TIME) ?: current.attack,


### PR DESCRIPTION
# What Changes
This commit updates the `SamplerViewModel` to correctly reconstruct the octave from the stored `pitchValue` instead of using a hardcoded value.

## Key Implementations :
- **`SamplerViewModel.kt`**:
    - Replaces the hardcoded value of 4 for `loadedPitchOctave` with a calculation derived from `pitchValue` and the size of `NOTE_ORDER`.
    - Constrains the calculated octave within the `minOctave` and `maxOctave` range using `coerceIn`.

## Notes
Closes #xxx
